### PR TITLE
Card Component children fix

### DIFF
--- a/mobile/src/components/card/card.tsx
+++ b/mobile/src/components/card/card.tsx
@@ -3,8 +3,6 @@ import {View} from 'react-native';
 import {styles} from './card.style';
 import {TCardProps} from './card.type';
 
-export const Card: FC<TCardProps> = ({containerStyle, renderDetails}) => {
-  return (
-    <View style={[styles.container, containerStyle]}>{renderDetails()}</View>
-  );
+export const Card: FC<TCardProps> = ({containerStyle, children}) => {
+  return <View style={[styles.container, containerStyle]}>{children}</View>;
 };

--- a/mobile/src/components/card/card.type.ts
+++ b/mobile/src/components/card/card.type.ts
@@ -4,7 +4,6 @@ import {TFoodItem, TRestaurant} from '../../types/data';
 export type TCardProps = {
   image?: string;
   title?: string;
-  renderDetails: () => {};
   containerStyle?: StyleProp<ViewStyle>;
 };
 

--- a/mobile/src/components/card/foodCard.tsx
+++ b/mobile/src/components/card/foodCard.tsx
@@ -9,8 +9,8 @@ export const FoodCard: FC<TFoodItemCardProps> = ({foodItem}) => {
   const {name, description, rating, usersVoted, price, favorite, imageName} =
     foodItem;
 
-  const render = () => (
-    <>
+  return (
+    <Card>
       <View>
         <Image
           style={styles.cardImage}
@@ -23,8 +23,6 @@ export const FoodCard: FC<TFoodItemCardProps> = ({foodItem}) => {
         <Text style={styles.title}>{name}</Text>
         <Text style={styles.details}>{description}</Text>
       </View>
-    </>
+    </Card>
   );
-
-  return <Card renderDetails={render} />;
 };

--- a/mobile/src/components/card/restaurantCard.tsx
+++ b/mobile/src/components/card/restaurantCard.tsx
@@ -19,8 +19,8 @@ export const RestaurantCard: FC<TRestaurantCardProps> = ({restaurant}) => {
     imageName,
   } = restaurant;
 
-  const render = () => (
-    <>
+  return (
+    <Card>
       <View>
         <Image
           style={styles.cardImage}
@@ -59,8 +59,6 @@ export const RestaurantCard: FC<TRestaurantCardProps> = ({restaurant}) => {
           ))}
         </ScrollView>
       </View>
-    </>
+    </Card>
   );
-
-  return <Card renderDetails={render} />;
 };


### PR DESCRIPTION
The card component will use the children prop instead of a renderDetails function.

IMPORTANT: If your screen/component uses the Card component directly you might have to modify it. Using the food and restaurant cards should work as before.